### PR TITLE
add string resource tool sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,5 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+tool/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+This repo has various samples, mainly to remind myself of how some things work outside of complex projects.
+
+# NUnitWorkaround
+This demonstrates a way to use NUnit 3.x asserts in vstest without having test failures accumulate messages from prior tests.
+
+# StringResourceTool
+Shows how to use the Microsoft.Data.Tools.StringResourceTool package to create strongly typed wrapper methods around localized format strings.

--- a/StringResourceTool/Directory.Build.props
+++ b/StringResourceTool/Directory.Build.props
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  This root MSBuild file is automatically imported for all projects in the tree by MSBuild 15.0 and serves as the central entry point for CBT.
+  You can have a hierarchy of imports but make sure that this file is still imported.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Global locations">
+    <!--
+      $(MSBuildAllProjects) is a list of files that determine if a project is up-to-date or not.  By including this
+      file in the list, it ensures that all projects will be rebuilt if it changes.
+    -->
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <!--
+      Enlistment root is based off of wherever this file is.  Be sure not to set this property anywhere else.
+    -->
+    <EnlistmentRoot>$(MSBuildThisFileDirectory.TrimEnd('\\'))</EnlistmentRoot>
+ 
+  </PropertyGroup>
+
+  
+</Project>

--- a/StringResourceTool/Directory.Build.targets
+++ b/StringResourceTool/Directory.Build.targets
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project >
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>  
+  <ItemDefinitionGroup>
+      <Sqlstringresource>
+      <namespace Condition="'$(rootnamespace)'!='' and '%(namespace)' == ''">$(rootnamespace)</namespace>
+      <namespace Condition="'$(rootnamespace)'=='' and '%(namespace)' == ''">%(filename)</namespace>
+      <outresxfilename Condition="'%(outresxfilename)'==''">%(filename)</outresxfilename>
+      <outcodefilename Condition="'%(outcodefilename)'==''">%(filename)</outcodefilename>
+      <outclassname Condition="'%(outclassname)'==''">%(filename)</outclassname>
+      <resourcename Condition="'%(resourcename)'==''">%(namespace)</resourcename>
+      <resourcename Condition="'%(resourcename)'!=''">%(resourcename)</resourcename>
+      <additionaloptions Condition="'%(additionaloptions)'==''"></additionaloptions>
+    </Sqlstringresource>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <Compile Include="@(Sqlstringresource -> '$(IntermediateOutputPath)%(outcodefilename).cs')" />
+  </ItemGroup>
+  <Target Name="sqlconvertstringresources"
+          BeforeTargets="AssignTargetPaths"
+          Inputs="$(MSBuildThisFileFullPath);@(Sqlstringresource->'%(fullpath)')"
+          Outputs="@(Sqlstringresource->'$(IntermediateOutputPath)%(outcodefilename).cs');@(sqlstringresource->'$(IntermediateOutputPath)%(outresxfilename).resx')"
+          Condition="'@(Sqlstringresource)'!=''">
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+    <Exec Condition="!Exists('$(EnlistmentRoot)\tool\srgen.exe')" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" Command="dotnet tool install Microsoft.Data.Tools.StringResourceTool --version 1.0.0  --ignore-failed-sources --add-source https://api.nuget.org/v3/index.json --tool-path $(EnlistmentRoot)\tool"  />
+    <Exec Command="$(EnlistmentRoot)\tool\srgen.exe -or $(IntermediateOutputPath)%(sqlstringresource.outresxfilename).resx -oc $(IntermediateOutputPath)%(sqlstringresource.outcodefilename).cs -ns %(sqlstringresource.namespace) -cn %(sqlstringresource.outclassname) -l CS %(sqlstringresource.additionaloptions) %(sqlstringresource.fullpath)" />
+    <ItemGroup>
+      <EmbeddedResource Include="$(IntermediateOutputPath)%(sqlstringresource.outresxfilename).resx">
+        <LogicalName Condition="'%(Sqlstringresource.logicalname)'!=''">%(Sqlstringresource.logicalname)</LogicalName>
+        <ManifestResourceName>%(Sqlstringresource.resourcename).%(Sqlstringresource.outclassname)</ManifestResourceName>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+ </Project>

--- a/StringResourceTool/LocalizableResources.strings
+++ b/StringResourceTool/LocalizableResources.strings
@@ -1,0 +1,16 @@
+# String resource file
+#
+# When processed by the String Resource Tool, this file generates
+# both a .CS and a .RESX file with the same name as the file.
+# The .CS file contains a class which can be used to access these
+# string resources, including the ability to format in
+# parameters, which are identified with the .NET {x} format
+# (see String.Format help).
+#
+# Lines starting with a semicolon ";" are also treated as comments
+#
+
+[strings]
+StringWithoutArguments=This string has no arguments
+StringWithUntypedArgument(argument)=This string was declared with an untyped argument. Value: {0}
+StringWithTypeArguments(int intArgument, string stringArgument, DateTime dateTimeArgument)=This string was declared with an int {0}, a string {1}, and a DateTime {2}

--- a/StringResourceTool/Program.cs
+++ b/StringResourceTool/Program.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace StringResourceTool
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine(LocalizableResources.StringWithoutArguments);
+            Console.WriteLine(LocalizableResources.StringWithTypeArguments(1, "mystring", DateTime.UtcNow));
+            Console.WriteLine(LocalizableResources.StringWithUntypedArgument("default type is string"));
+        }
+    }
+}

--- a/StringResourceTool/StringResourceTool.csproj
+++ b/StringResourceTool/StringResourceTool.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Sqlstringresource Include="*.strings" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
If someone knows a better way to integrate a `dotnet tool`-style nuget package into msbuild, I'd love to see how. 
Visual Studio 2017 won't even load a project that has `<PackageReference>` to it, I haven't tried VS 2019 yet.
